### PR TITLE
fix: back quotes in PR title attempts to execute code

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,8 +34,8 @@ runs:
     - name: Lint message
       shell: bash
       run: |
-        MESSAGE="${{ inputs.message }}"
+        MESSAGE='${{ inputs.message }}'
         if [ -z "$MESSAGE" ]; then
-          MESSAGE="${{ github.event.pull_request.title }}"
+          MESSAGE='${{ github.event.pull_request.title }}'
         fi
         echo "$MESSAGE" | npx commitlint --verbose


### PR DESCRIPTION
This pull request makes a minor update to the `runs` section in `action.yml`, changing the way shell variables are assigned from double quotes to single quotes for the `MESSAGE` variable. This affects how input and event data are handled in the linting step. Specifically this will stop words in backquotes from being interpreted as shell commands, fixing a bug that would allow anyone submitting a PR to execute arbitrary code in our GitHub Actions.

Resolves #1 